### PR TITLE
Node weights and node weights attr quantization configs clean-up - remove temporary patch for fields from QuantizationConfig

### DIFF
--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -64,8 +64,7 @@ class BaseNodeQuantizationConfig(object):
         if hasattr(self, config_parameter_name):
             setattr(self, config_parameter_name, config_parameter_value)
         else:
-            Logger.warning(f"Parameter {config_parameter_name} could not be found in the node quantization config and "
-                           f"was not updated!")
+            raise AttributeError(f"Parameter {config_parameter_name} could not be found in the node quantization config")
 
     def __repr__(self) -> str:
         """
@@ -168,15 +167,6 @@ class WeightsAttrQuantizationConfig:
         self.enable_weights_quantization = weights_attr_cfg.enable_weights_quantization
         self.weights_quantization_params = {}
 
-        # TODO irena remove along with set_qc. Keeping for eq and hash to work without set_qc being called
-        self.weights_error_method = None
-        self.l_p_value = None
-
-    def set_qc(self, qc: QuantizationConfig):
-        # TODO irena: temporary keep the fields to not break everything at once.
-        self.weights_error_method = qc.weights_error_method
-        self.l_p_value = qc.l_p_value
-
     def set_weights_quantization_param(self,
                                        weights_params: dict):
         """
@@ -207,18 +197,14 @@ class WeightsAttrQuantizationConfig:
                self.weights_quantization_method == other.weights_quantization_method and \
                self.weights_n_bits == other.weights_n_bits and \
                self.weights_per_channel_threshold == other.weights_per_channel_threshold and \
-               self.enable_weights_quantization == other.enable_weights_quantization and \
-               self.weights_error_method == other.weights_error_method and \
-               self.l_p_value == other.l_p_value
+               self.enable_weights_quantization == other.enable_weights_quantization
 
     def __hash__(self):
         return hash((self.weights_channels_axis,
-                     self.weights_error_method,
                      self.weights_quantization_method,
                      self.weights_n_bits,
                      self.weights_per_channel_threshold,
-                     self.enable_weights_quantization,
-                     self.l_p_value))
+                     self.enable_weights_quantization))
 
 
 class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):

--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -273,13 +273,11 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
                 self.attributes_config_mapping[attr] = WeightsAttrQuantizationConfig(weights_attr_cfg=attr_cfg,
                                                                                      weights_channels_axis=weights_channels_axis)
         # TODO irena remove along with set_qc. Keeping for eq and hash to work without set_qc being called
-        self.min_threshold = None
         self.weights_second_moment_correction = None
         self.weights_bias_correction = None
 
     def set_qc(self, qc: QuantizationConfig):
         # TODO irena: temporary keep the fields to not break everything at once.
-        self.min_threshold = qc.min_threshold
         self.weights_second_moment_correction = qc.weights_second_moment_correction
         self.weights_bias_correction = qc.weights_bias_correction
 
@@ -436,8 +434,7 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
         if not isinstance(other, NodeWeightsQuantizationConfig):
             return False  # pragma: no cover
 
-        return self.min_threshold == other.min_threshold and \
-            self.simd_size == other.simd_size and \
+        return self.simd_size == other.simd_size and \
             self.weights_second_moment_correction == other.weights_second_moment_correction and \
             self.weights_bias_correction == other.weights_bias_correction and \
             self.attributes_config_mapping.keys() == other.attributes_config_mapping.keys() and \
@@ -448,8 +445,7 @@ class NodeWeightsQuantizationConfig(BaseNodeQuantizationConfig):
                  for k in self.pos_attributes_config_mapping.keys()])
 
     def __hash__(self):
-        return hash((self.min_threshold,
-                     self.simd_size,
+        return hash((self.simd_size,
                      self.weights_second_moment_correction,
                      self.weights_bias_correction,
                      frozenset(self.attributes_config_mapping),

--- a/model_compression_toolkit/core/common/quantization/node_quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/node_quantization_config.py
@@ -64,7 +64,8 @@ class BaseNodeQuantizationConfig(object):
         if hasattr(self, config_parameter_name):
             setattr(self, config_parameter_name, config_parameter_value)
         else:
-            raise AttributeError(f"Parameter {config_parameter_name} could not be found in the node quantization config")
+            Logger.warning(f"Parameter {config_parameter_name} could not be found in the node quantization config and "
+                           f"was not updated!")
 
     def __repr__(self) -> str:
         """

--- a/model_compression_toolkit/core/common/quantization/quantization_config.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_config.py
@@ -90,7 +90,6 @@ class QuantizationConfig:
     shift_negative_activation_correction: bool = True
     activation_channel_equalization: bool = False
     z_threshold: float = math.inf
-    min_threshold: float = MIN_THRESHOLD
     l_p_value: int = 2
     linear_collapsing: bool = True
     residual_collapsing: bool = True

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_activations_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_activations_computation.py
@@ -18,6 +18,7 @@ from typing import Dict, Union, Optional, Tuple, Callable
 from mct_quantizers import QuantizationMethod
 
 import model_compression_toolkit.core.common.quantization.quantization_params_generation as qpg
+from model_compression_toolkit.constants import MIN_THRESHOLD
 from model_compression_toolkit.target_platform_capabilities.schema.mct_current_schema import Signedness
 from model_compression_toolkit.core.common.collectors.statistics_collector import BaseStatsCollector
 from model_compression_toolkit.core.common.node_prior_info import NodePriorInfo
@@ -64,7 +65,7 @@ def compute_activation_qparams(quant_cfg: QuantizationConfig,
         node_activation_quant_cfg.activation_n_bits,
         min_value,
         max_value,
-        min_threshold=quant_cfg.min_threshold,
+        min_threshold=MIN_THRESHOLD,
         quant_error_method=quant_cfg.activation_error_method,
         is_signed=signed
     )

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_computation.py
@@ -94,13 +94,12 @@ def calculate_quantization_params(graph: Graph,
                                            f"'{attr}' in node '{n.name}' with the default MSE error method instead.")
                             weights_error_method = QuantizationErrorMethod.MSE
 
-                    min_threshold = candidate_qc.weights_quantization_cfg.min_threshold
                     weights_params, output_channels_axis = compute_weights_qparams(n.get_weights_by_keys(attr),
                                                                                    attr_cfg,
                                                                                    weights_error_method,
                                                                                    quant_cfg.l_p_value,
                                                                                    output_channels_axis,
-                                                                                   min_threshold=min_threshold, node=n,
+                                                                                   node=n,
                                                                                    hessian_info_service=hessian_info_service,
                                                                                    num_hessian_samples=num_hessian_samples)
                     attr_cfg.weights_channels_axis = ChannelAxisMapping(output_channels_axis, attr_cfg.weights_channels_axis.input)

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_computation.py
@@ -31,28 +31,6 @@ from model_compression_toolkit.core.common.quantization.quantization_params_gene
 from model_compression_toolkit.logger import Logger
 
 
-def _collect_nodes_for_hmse(nodes_list: List[BaseNode], graph: Graph) -> List[BaseNode]:
-    """
-    Collects nodes that are compatiable for parameters selection search using HMSE,
-    that is, have a kernel attribute that is configured for HMSE error method.
-
-    Args:
-        nodes_list: A list of nodes to search quantization parameters for.
-        graph: Graph to compute its nodes' quantization parameters..
-
-    Returns: A (possibly empty) list of nodes.
-
-    """
-    hmse_nodes = []
-    for n in nodes_list:
-        if n.kernel_attr is not None and n.is_weights_quantization_enabled(n.kernel_attr) and \
-            all([c.weights_quantization_cfg.get_attr_config(n.kernel_attr).weights_error_method ==
-                 QuantizationErrorMethod.HMSE for c in n.candidates_quantization_cfg]):
-            hmse_nodes.append(n)
-
-    return hmse_nodes
-
-
 def calculate_quantization_params(graph: Graph,
                                   quant_cfg: QuantizationConfig,
                                   fw_impl: FrameworkImplementation,
@@ -87,15 +65,16 @@ def calculate_quantization_params(graph: Graph,
     # Collecting nodes that are configured to search weights quantization parameters using HMSE optimization
     # and computing required Hessian information to be used for HMSE parameters selection.
     # The Hessian scores are computed and stored in the hessian_info_service object.
-    nodes_for_hmse = _collect_nodes_for_hmse(nodes_list, graph)
-    if len(nodes_for_hmse) > 0:
-        dataloader = fw_impl.convert_data_gen_to_dataloader(repr_data_gen_fn, batch_size=1)
-        request = HessianScoresRequest(mode=HessianMode.WEIGHTS,
-                                       granularity=HessianScoresGranularity.PER_ELEMENT,
-                                       data_loader=dataloader,
-                                       n_samples=num_hessian_samples,
-                                       target_nodes=nodes_for_hmse)
-        hessian_info_service.fetch_hessian(request)
+    if quant_cfg.weights_error_method == QuantizationErrorMethod.HMSE:
+        nodes_for_hmse = [n for n in nodes_list if n.kernel_attr and n.is_weights_quantization_enabled(n.kernel_attr)]
+        if nodes_for_hmse:
+            dataloader = fw_impl.convert_data_gen_to_dataloader(repr_data_gen_fn, batch_size=1)
+            request = HessianScoresRequest(mode=HessianMode.WEIGHTS,
+                                           granularity=HessianScoresGranularity.PER_ELEMENT,
+                                           data_loader=dataloader,
+                                           n_samples=num_hessian_samples,
+                                           target_nodes=nodes_for_hmse)
+            hessian_info_service.fetch_hessian(request)
 
     for n in tqdm(nodes_list, "Calculating quantization parameters"):  # iterate only nodes that we should compute their thresholds
         for candidate_qc in n.candidates_quantization_cfg:
@@ -103,27 +82,24 @@ def calculate_quantization_params(graph: Graph,
                 if n.is_weights_quantization_enabled(attr):
                     # If the node's weights attribute should be quantized, we compute its quantization parameters
                     attr_cfg = candidate_qc.weights_quantization_cfg.get_attr_config(attr)
-                    channels_axis = attr_cfg.weights_channels_axis
-                    if channels_axis is not None:
-                        output_channels_axis = channels_axis[0]
-                    else:
-                        output_channels_axis = None
+                    output_channels_axis = attr_cfg.weights_channels_axis.output
 
-                    mod_attr_cfg = attr_cfg
-
-                    if attr_cfg.weights_error_method == QuantizationErrorMethod.HMSE:
+                    weights_error_method = quant_cfg.weights_error_method
+                    if weights_error_method == QuantizationErrorMethod.HMSE:
                         # Although we collected nodes for HMSE before running the loop, we keep this verification to
                         # notify the user in case of HMSE configured for node that is not compatible for this method
                         if n.kernel_attr is None or n.kernel_attr not in attr:
                             Logger.warning(f"The HMSE error method for parameters selection is only supported for "
                                            f"kernel weights attributes. Running parameters selection for attribute "
                                            f"'{attr}' in node '{n.name}' with the default MSE error method instead.")
-                            mod_attr_cfg = copy.deepcopy(attr_cfg)
-                            mod_attr_cfg.weights_error_method = QuantizationErrorMethod.MSE
+                            weights_error_method = QuantizationErrorMethod.MSE
 
                     min_threshold = candidate_qc.weights_quantization_cfg.min_threshold
                     weights_params, output_channels_axis = compute_weights_qparams(n.get_weights_by_keys(attr),
-                                                                                   mod_attr_cfg, output_channels_axis,
+                                                                                   attr_cfg,
+                                                                                   weights_error_method,
+                                                                                   quant_cfg.l_p_value,
+                                                                                   output_channels_axis,
                                                                                    min_threshold=min_threshold, node=n,
                                                                                    hessian_info_service=hessian_info_service,
                                                                                    num_hessian_samples=num_hessian_samples)

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
@@ -19,6 +19,7 @@ import numpy as np
 from mct_quantizers import QuantizationMethod
 
 from model_compression_toolkit.constants import NUM_QPARAM_HESSIAN_SAMPLES
+from model_compression_toolkit.core import QuantizationConfig, QuantizationErrorMethod
 from model_compression_toolkit.core.common.hessian import HessianInfoService
 from model_compression_toolkit.core.common.quantization.quantization_params_generation import \
     power_of_two_selection_tensor, lut_kmeans_tensor, symmetric_selection_tensor, uniform_selection_tensor
@@ -28,8 +29,10 @@ if TYPE_CHECKING:
     from model_compression_toolkit.core.common.quantization.node_quantization_config import WeightsAttrQuantizationConfig
 
 
-def compute_weights_qparams(weights_attr_values: np.ndarray,
+def compute_weights_qparams(weights_attr_data: np.ndarray,
                             attr_quant_config: 'WeightsAttrQuantizationConfig',
+                            weights_error_method: QuantizationErrorMethod,
+                            l_p_value: int,
                             output_channels_axis: int,
                             min_threshold: float,
                             node=None,
@@ -40,7 +43,8 @@ def compute_weights_qparams(weights_attr_values: np.ndarray,
     instance.
 
     Args:
-        weights_attr_values: Weights attribute parameter to compute the quantization thresholds for.
+        weights_attr_data: Weights attribute parameter to compute the quantization thresholds for.
+        quant_cfg: quantization config.
         attr_quant_config: A specific weights attribute quantization configuration to get its params.
         output_channels_axis: Index of the kernel output channels dimension.
         min_threshold: Minimal threshold to use if threshold is too small.
@@ -54,13 +58,13 @@ def compute_weights_qparams(weights_attr_values: np.ndarray,
     """
     params_fn = _get_weights_quantization_params_fn(attr_quant_config.weights_quantization_method)
     weights_params, output_channels_axis = params_fn(
-        weights_attr_values,
-        p=attr_quant_config.l_p_value,
+        weights_attr_data,
+        p=l_p_value,
         n_bits=attr_quant_config.weights_n_bits,
         per_channel=attr_quant_config.weights_per_channel_threshold,
         channel_axis=output_channels_axis,
         min_threshold=min_threshold,
-        quant_error_method=attr_quant_config.weights_error_method,
+        quant_error_method=weights_error_method,
         node=node,
         hessian_info_service=hessian_info_service,
         num_hessian_samples=num_hessian_samples)

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
@@ -19,7 +19,7 @@ import numpy as np
 from mct_quantizers import QuantizationMethod
 
 from model_compression_toolkit.constants import NUM_QPARAM_HESSIAN_SAMPLES
-from model_compression_toolkit.core import QuantizationConfig, QuantizationErrorMethod
+from model_compression_toolkit.core import QuantizationErrorMethod
 from model_compression_toolkit.core.common.hessian import HessianInfoService
 from model_compression_toolkit.core.common.quantization.quantization_params_generation import \
     power_of_two_selection_tensor, lut_kmeans_tensor, symmetric_selection_tensor, uniform_selection_tensor
@@ -44,8 +44,9 @@ def compute_weights_qparams(weights_attr_data: np.ndarray,
 
     Args:
         weights_attr_data: Weights attribute parameter to compute the quantization thresholds for.
-        quant_cfg: quantization config.
         attr_quant_config: A specific weights attribute quantization configuration to get its params.
+        weights_error_method: quantization error method.
+        l_p_value: p-norm to use for the Lp-norm distance.
         output_channels_axis: Index of the kernel output channels dimension.
         min_threshold: Minimal threshold to use if threshold is too small.
         node: The node for which the quantization error is computed (used only with HMSE error method).

--- a/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
+++ b/model_compression_toolkit/core/common/quantization/quantization_params_generation/qparams_weights_computation.py
@@ -18,7 +18,7 @@ from typing import Dict, Any, Tuple, Callable, TYPE_CHECKING
 import numpy as np
 from mct_quantizers import QuantizationMethod
 
-from model_compression_toolkit.constants import NUM_QPARAM_HESSIAN_SAMPLES
+from model_compression_toolkit.constants import NUM_QPARAM_HESSIAN_SAMPLES, MIN_THRESHOLD
 from model_compression_toolkit.core import QuantizationErrorMethod
 from model_compression_toolkit.core.common.hessian import HessianInfoService
 from model_compression_toolkit.core.common.quantization.quantization_params_generation import \
@@ -34,7 +34,7 @@ def compute_weights_qparams(weights_attr_data: np.ndarray,
                             weights_error_method: QuantizationErrorMethod,
                             l_p_value: int,
                             output_channels_axis: int,
-                            min_threshold: float,
+                            min_threshold: float = MIN_THRESHOLD,
                             node=None,
                             hessian_info_service: HessianInfoService = None,
                             num_hessian_samples: int = NUM_QPARAM_HESSIAN_SAMPLES) -> Tuple[Dict[Any, Any], int]:

--- a/model_compression_toolkit/core/common/statistics_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/core/common/statistics_correction/apply_bias_correction_to_graph.py
@@ -36,7 +36,7 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        if (n.final_weights_quantization_cfg.bias_corrected is not None and
+        if (n.final_weights_quantization_cfg and n.final_weights_quantization_cfg.bias_corrected is not None and
                 not n.final_weights_quantization_cfg.weights_second_moment_correction):
             _apply_bias_correction_to_node(n, fw_impl)
     return graph

--- a/model_compression_toolkit/core/common/statistics_correction/apply_bias_correction_to_graph.py
+++ b/model_compression_toolkit/core/common/statistics_correction/apply_bias_correction_to_graph.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 import copy
 
-from model_compression_toolkit.core.common.quantization.quantization_config import QuantizationConfig
-from model_compression_toolkit.core import CoreConfig
 from model_compression_toolkit.core.common import Graph, BaseNode
 from model_compression_toolkit.core.common.framework_implementation import FrameworkImplementation
 from model_compression_toolkit.core.common.quantization.node_quantization_config import WeightsAttrQuantizationConfig
@@ -23,7 +21,6 @@ from model_compression_toolkit.target_platform_capabilities.schema.mct_current_s
 
 
 def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
-                                   core_config: CoreConfig,
                                    fw_impl: FrameworkImplementation) -> Graph:
     """
     Get a graph, where each node has a final weights quantization configuration (with a bias
@@ -31,7 +28,6 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     Args:
         graph_to_apply_bias_correction: Graph to apply bias correction to.
-        core_config: CoreConfig containing parameters of how the model should be quantized.
         fw_impl: FrameworkImplementation object with a specific framework methods implementation.
 
     Returns:
@@ -40,20 +36,14 @@ def apply_bias_correction_to_graph(graph_to_apply_bias_correction: Graph,
 
     graph = copy.deepcopy(graph_to_apply_bias_correction)
     for n in graph.nodes:
-        # bias correction is only relevant for nodes with kernel op
-        if core_config.quantization_config.weights_bias_correction and n.kernel_attr is not None and \
-            n.is_weights_quantization_enabled(n.kernel_attr) and \
-                not n.final_weights_quantization_cfg.weights_second_moment_correction:
-            # If a kernel was quantized and weights bias correction is enabled in n.quantization_cfg,
-            # a bias correction term was calculated during model preparation, and is used now in the node's bias term.
-            if n.final_weights_quantization_cfg.weights_bias_correction:
-                _apply_bias_correction_to_node(n, fw_impl, core_config.quantization_config)
+        if (n.final_weights_quantization_cfg.bias_corrected is not None and
+                not n.final_weights_quantization_cfg.weights_second_moment_correction):
+            _apply_bias_correction_to_node(n, fw_impl)
     return graph
 
 
 def _apply_bias_correction_to_node(node: BaseNode,
-                                   fw_impl: FrameworkImplementation,
-                                   qc: QuantizationConfig):
+                                   fw_impl: FrameworkImplementation):
     """
     Set new bias to node using the bias-correction term that is stored in the
     final weights quantization configuration.

--- a/model_compression_toolkit/core/common/statistics_correction/statistics_correction.py
+++ b/model_compression_toolkit/core/common/statistics_correction/statistics_correction.py
@@ -56,8 +56,9 @@ def statistics_correction_runner(transformed_graph: Graph,
     ########################################################
     # Compute bias correction to nodes' config candidates
     ########################################################
-    tg_with_bias = compute_bias_correction_of_graph(tg_with_bias,
-                                                    fw_impl)
+    if core_config.quantization_config.weights_bias_correction:
+        tg_with_bias = compute_bias_correction_of_graph(tg_with_bias,
+                                                        fw_impl)
 
     if tb_w is not None:
         tb_w.add_graph(tg_with_bias, 'statistics_computation')
@@ -96,7 +97,6 @@ def apply_statistics_correction(transformed_graph: Graph,
     #############################################
     if core_config.quantization_config.weights_bias_correction:
         transformed_graph = apply_bias_correction_to_graph(transformed_graph,
-                                                           core_config,
                                                            fw_impl=fw_impl)
     if tb_w is not None:
         tb_w.add_graph(transformed_graph, 'after_statistics_correction')

--- a/model_compression_toolkit/core/graph_prep_runner.py
+++ b/model_compression_toolkit/core/graph_prep_runner.py
@@ -153,16 +153,10 @@ def get_finalized_graph(initial_graph: Graph,
     if bit_width_config:
         set_manual_bitwidth_config(graph, bit_width_config)
 
-    # TODO irena: load_fqc_configuration only loads config from tpc. Previously quant_config was read as well.
-    #  As a first stage we keep the attributes in internal configs and fill them manually from quant_config
-    #  not to break all the code at once. Eventually we need to handle quant_config directly, without injecting into candidates.
-    #  TODO 2: Also we adjust candidates for single precision, which we shouldn't do here.
-    def update(qc):
-        qc.weights_quantization_cfg.set_qc(quant_config)
+    # TODO irena: remove after base config is used
     for n in transformed_graph.nodes:
         if not mixed_precision_enable:
             n.quantization_cfg.candidates_quantization_cfg = [n.quantization_cfg.base_quantization_cfg]
-        n.quantization_cfg.update_all(update)
 
     ######################################
     # Channel equalization

--- a/model_compression_toolkit/core/graph_prep_runner.py
+++ b/model_compression_toolkit/core/graph_prep_runner.py
@@ -159,9 +159,6 @@ def get_finalized_graph(initial_graph: Graph,
     #  TODO 2: Also we adjust candidates for single precision, which we shouldn't do here.
     def update(qc):
         qc.weights_quantization_cfg.set_qc(quant_config)
-        for attr_cfg in qc.weights_quantization_cfg.get_all_weight_attrs_configs().values():
-            attr_cfg.weights_error_method = quant_config.weights_error_method
-            attr_cfg.l_p_value = quant_config.l_p_value
     for n in transformed_graph.nodes:
         if not mixed_precision_enable:
             n.quantization_cfg.candidates_quantization_cfg = [n.quantization_cfg.base_quantization_cfg]

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/input_scaling.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/input_scaling.py
@@ -111,8 +111,7 @@ class BaseInputScaling(common.BaseSubstitution):
                                                       attr_quant_config=attr_cfg,
                                                       weights_error_method=self.quant_cfg.weights_error_method,
                                                       l_p_value=self.quant_cfg.l_p_value,
-                                                      output_channels_axis=attr_cfg.weights_channels_axis.output,
-                                                      min_threshold=nqc.weights_quantization_cfg.min_threshold)
+                                                      output_channels_axis=attr_cfg.weights_channels_axis.output)
                 attr_cfg.set_weights_quantization_param(w_params)
 
         return graph

--- a/model_compression_toolkit/core/keras/graph_substitutions/substitutions/input_scaling.py
+++ b/model_compression_toolkit/core/keras/graph_substitutions/substitutions/input_scaling.py
@@ -17,7 +17,7 @@
 from tensorflow.keras.layers import InputLayer, Dense, DepthwiseConv2D, Conv2D, Conv2DTranspose, ZeroPadding2D
 from typing import List
 
-from model_compression_toolkit.core import common
+from model_compression_toolkit.core import common, QuantizationConfig
 from model_compression_toolkit.core.common.graph.base_graph import Graph
 from model_compression_toolkit.core.common.graph.graph_matchers import NodeOperationMatcher, WalkMatcher
 from model_compression_toolkit.core.common.graph.base_node import BaseNode
@@ -47,7 +47,8 @@ class BaseInputScaling(common.BaseSubstitution):
     """
 
     def __init__(self,
-                 matcher_instance):
+                 matcher_instance,
+                 quant_cfg: QuantizationConfig):
         """
         Matches: InputLayer -> (optional nodes) -> (Dense,Conv2D,DepthwiseConv2D,Conv2DTranspose)
         note: the optional nodes are nodes that don't affect the scaling (such as ZeroPadding)
@@ -55,10 +56,11 @@ class BaseInputScaling(common.BaseSubstitution):
         Create a substitution using different params which may affect the way this substitution is made.
         The substitution is looking for edges in the graph which are input layers connected to linear layers.
         Args:
-            matcher_instance: matcher instance of type WalkMatcher
-
+            matcher_instance: matcher instance of type WalkMatcher.
+            quant_cfg: quantization config.
         """
         super().__init__(matcher_instance=matcher_instance)
+        self.quant_cfg = quant_cfg
 
     def substitute(self,
                    graph: Graph,
@@ -105,7 +107,10 @@ class BaseInputScaling(common.BaseSubstitution):
             for nqc in linear_layer.candidates_quantization_cfg:
                 attr_cfg = nqc.weights_quantization_cfg.get_attr_config(linear_layer.kernel_attr)
                 assert attr_cfg.enable_weights_quantization
-                w_params, _ = compute_weights_qparams(w1_fixed, attr_quant_config=attr_cfg,
+                w_params, _ = compute_weights_qparams(w1_fixed,
+                                                      attr_quant_config=attr_cfg,
+                                                      weights_error_method=self.quant_cfg.weights_error_method,
+                                                      l_p_value=self.quant_cfg.l_p_value,
                                                       output_channels_axis=attr_cfg.weights_channels_axis.output,
                                                       min_threshold=nqc.weights_quantization_cfg.min_threshold)
                 attr_cfg.set_weights_quantization_param(w_params)
@@ -118,12 +123,15 @@ class InputScaling(BaseInputScaling):
     Substitution extends BaseInputScaling to the case of Input-->Linear
     """
 
-    def __init__(self):
+    def __init__(self, quant_cfg: QuantizationConfig):
         """
         Initialize a ScaleEqualization object.
+
+        Args:
+            quant_cfg: quantization config.
         """
 
-        super().__init__(matcher_instance=INPUT_MATCHER)
+        super().__init__(matcher_instance=INPUT_MATCHER, quant_cfg=quant_cfg)
 
 
 class InputScalingWithPad(BaseInputScaling):
@@ -131,9 +139,12 @@ class InputScalingWithPad(BaseInputScaling):
     Substitution extends BaseInputScaling to the case of Input-->ZeroPadding-->Linear
     """
 
-    def __init__(self):
+    def __init__(self, quant_cfg: QuantizationConfig):
         """
         Initialize a ScaleEqualization object.
+
+        Args:
+            quant_cfg: quantization config.
         """
 
-        super().__init__(matcher_instance=INPUT_MATCHER_WITH_PAD)
+        super().__init__(matcher_instance=INPUT_MATCHER_WITH_PAD, quant_cfg=quant_cfg)

--- a/model_compression_toolkit/core/keras/keras_implementation.py
+++ b/model_compression_toolkit/core/keras/keras_implementation.py
@@ -357,8 +357,8 @@ class KerasImplementation(FrameworkImplementation):
         if quant_config.softmax_shift:
             substitutions_list.append(keras_softmax_shift())
         if quant_config.input_scaling:
-            substitutions_list.append(InputScaling())
-            substitutions_list.append(InputScalingWithPad())
+            substitutions_list.append(InputScaling(quant_config))
+            substitutions_list.append(InputScalingWithPad(quant_config))
         if quant_config.concat_threshold_update:
             substitutions_list.append(ConcatThresholdUpdate())
         return substitutions_list

--- a/model_compression_toolkit/trainable_infrastructure/common/get_quantizer_config.py
+++ b/model_compression_toolkit/trainable_infrastructure/common/get_quantizer_config.py
@@ -48,7 +48,6 @@ def get_trainable_quantizer_weights_config(
                                            final_attr_cfg.enable_weights_quantization,
                                            final_attr_cfg.weights_channels_axis[0],  # Output channel axis
                                            final_attr_cfg.weights_per_channel_threshold,
-                                           final_node_cfg.min_threshold,
                                            weights_quantization_candidates)
 
 

--- a/model_compression_toolkit/trainable_infrastructure/common/trainable_quantizer_config.py
+++ b/model_compression_toolkit/trainable_infrastructure/common/trainable_quantizer_config.py
@@ -70,7 +70,6 @@ class TrainableQuantizerWeightsConfig:
                  enable_weights_quantization: bool,
                  weights_channels_axis: int,
                  weights_per_channel_threshold: bool,
-                 min_threshold: float,
                  weights_quantization_candidates: List[TrainableQuantizerCandidateConfig] = None,
                  ):
         """
@@ -83,7 +82,6 @@ class TrainableQuantizerWeightsConfig:
             enable_weights_quantization (bool): Whether to quantize the layer's weights or not.
             weights_channels_axis (int): Axis to quantize a node's kernel when quantizing per-channel.
             weights_per_channel_threshold (bool): Whether to quantize the weights per-channel or not (per-tensor).
-            min_threshold (float): Minimum threshold to use during thresholds selection.
         """
         self.weights_quantization_method = weights_quantization_method
         self.weights_n_bits = weights_n_bits
@@ -91,5 +89,4 @@ class TrainableQuantizerWeightsConfig:
         self.enable_weights_quantization = enable_weights_quantization
         self.weights_channels_axis = weights_channels_axis
         self.weights_per_channel_threshold = weights_per_channel_threshold
-        self.min_threshold = min_threshold
         self.weights_bits_candidates = weights_quantization_candidates

--- a/model_compression_toolkit/trainable_infrastructure/keras/config_serialization.py
+++ b/model_compression_toolkit/trainable_infrastructure/keras/config_serialization.py
@@ -77,8 +77,7 @@ def config_deserialization(in_config: dict) -> Union[TrainableQuantizerWeightsCo
                                                weights_quantization_params=weights_quantization_params,
                                                enable_weights_quantization=in_config[C.ENABLE_WEIGHTS_QUANTIZATION],
                                                weights_channels_axis=in_config[C.WEIGHTS_CHANNELS_AXIS],
-                                               weights_per_channel_threshold=in_config[C.WEIGHTS_PER_CHANNEL_THRESHOLD],
-                                               min_threshold=in_config[C.MIN_THRESHOLD])
+                                               weights_per_channel_threshold=in_config[C.WEIGHTS_PER_CHANNEL_THRESHOLD])
     elif in_config[C.IS_ACTIVATIONS]:
         return TrainableQuantizerActivationConfig(activation_quantization_method=QuantizationMethod(in_config[C.ACTIVATION_QUANTIZATION_METHOD]),
                                                   activation_n_bits=in_config[C.ACTIVATION_N_BITS],

--- a/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/network_editor/edit_qc_test.py
@@ -224,7 +224,7 @@ class ChangeCandidatesWeightsQuantConfigAttrTest(BaseChangeQuantConfigAttrTest):
 
     def __init__(self, unit_test):
         edit_filter = NodeTypeFilter(layers.Conv2D)
-        action = ChangeCandidatesWeightsQuantConfigAttr(weights_bias_correction=False)
+        action = ChangeCandidatesWeightsQuantConfigAttr(weights_second_moment_correction=True)
         prepare_graph_func = prepare_graph_for_first_network_editor
         super().__init__(unit_test, edit_filter=edit_filter, action=action, prepare_graph_func=prepare_graph_func)
 
@@ -242,7 +242,7 @@ class ChangeFinalsWeightsQuantConfigAttrTest(BaseChangeQuantConfigAttrTest):
 
     def __init__(self, unit_test):
         edit_filter = NodeTypeFilter(layers.Conv2D)
-        action = ChangeFinalWeightsQuantConfigAttr(weights_bias_correction=False)
+        action = ChangeFinalWeightsQuantConfigAttr(weights_second_moment_correction=True)
         prepare_graph_func = prepare_graph_for_second_network_editor
         super().__init__(unit_test, edit_filter=edit_filter, action=action, prepare_graph_func=prepare_graph_func)
 

--- a/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
+++ b/tests/keras_tests/feature_networks_tests/feature_networks/test_kmeans_quantizer.py
@@ -94,15 +94,7 @@ class KmeansQuantizerTestBase(BaseKerasFeatureNetworkTest):
         return mct.core.DebugConfig(network_editor=[EditRule(filter=NodeNameFilter(self.node_to_change_name),
                                                              action=ChangeCandidatesWeightsQuantConfigAttr(
                                                                  attr_name=KERNEL,
-                                                                 weights_quantization_method=QuantizationMethod.POWER_OF_TWO)),
-                                                    EditRule(filter=NodeNameFilter(self.node_to_change_name),
-                                                             action=ChangeCandidatesWeightsQuantConfigAttr(
-                                                                 attr_name=KERNEL,
-                                                                 weights_quantization_fn=power_of_two_quantizer)),
-                                                    EditRule(filter=NodeNameFilter(self.node_to_change_name),
-                                                             action=ChangeCandidatesWeightsQuantConfigAttr(
-                                                                 attr_name=KERNEL,
-                                                                 weights_quantization_params_fn=power_of_two_selection_tensor)),
+                                                                 weights_quantization_method=QuantizationMethod.POWER_OF_TWO))
                                                     ])
 
     def compare(self, quantized_model, float_model, input_x=None, quantization_info=None):

--- a/tests/keras_tests/feature_networks_tests/test_features_runner.py
+++ b/tests/keras_tests/feature_networks_tests/test_features_runner.py
@@ -182,7 +182,8 @@ class FeatureNetworkTest(unittest.TestCase):
         DwConv2dReplacementTest(self).run_test()
 
     def test_change_qc_attr(self):
-        ChangeFinalWeightQCAttrTest(self).run_test()
+        # there are no fields that can be changed in final cfg and have any effect (unless the whole attr cfgs mapping is overridden)
+        # ChangeFinalWeightQCAttrTest(self).run_test()
         ChangeFinalActivationQCAttrTest(self).run_test()
 
     def test_edit_candidate_qc(self):

--- a/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/keras_tests/function_tests/test_gptq_soft_quantizer.py
@@ -46,8 +46,7 @@ def wrap_test_model(model, per_channel=False, param_learning=False):
                                            weights_quantization_params={THRESHOLD: 2.0},
                                            enable_weights_quantization=True,
                                            weights_channels_axis=3,
-                                           weights_per_channel_threshold=per_channel,
-                                           min_threshold=MIN_THRESHOLD)
+                                           weights_per_channel_threshold=per_channel)
 
     sq = SymmetricSoftRoundingGPTQ(quantization_config=tqwc,
                                    quantization_parameter_learning=param_learning)

--- a/tests/keras_tests/function_tests/test_node_quantization_configurations.py
+++ b/tests/keras_tests/function_tests/test_node_quantization_configurations.py
@@ -38,12 +38,10 @@ class TestNodeQuantizationConfigurations(unittest.TestCase):
                                                     "new activation_n_bits should be 4.")
         self.assertFalse(nac == og_nac)
 
-        update_nac = copy.deepcopy(nac)
-
-        nac.set_quant_config_attr("activation_M_bits", 8)
-        self.assertFalse(nac.activation_n_bits == 8, "Expects set_quant_config_attr to not update, "
-                                                     "activation_n_bits should be 4.")
-        self.assertTrue(nac == update_nac)
+        with self.assertRaises(AttributeError) as e:
+            nac.set_quant_config_attr("activation_M_bits", 8)
+        self.assertEqual(str(e.exception),
+                         "Parameter activation_M_bits could not be found in the node quantization config.")
 
     def test_weights_set_quant_config_attribute(self):
         op_cfg, _, _ = get_op_quantization_configs()
@@ -52,15 +50,6 @@ class TestNodeQuantizationConfigurations(unittest.TestCase):
                                             weights_channels_axis=ChannelAxisMapping(1, -1),
                                             node_attrs_list=[KERNEL, 0])
         og_nwc = copy.deepcopy(nwc)
-
-        # Updating a config parameter, not weights attribute parameter (no attr_name passed)
-        # TODO irena: weights_bias_correction should be removed
-        # self.assertTrue(nwc.weights_bias_correction)
-        nwc.set_quant_config_attr("weights_bias_correction", False)
-        self.assertFalse(nwc.weights_bias_correction)
-        self.assertFalse(nwc == og_nwc)
-
-        nwc = copy.deepcopy(og_nwc)
 
         # Updating an attribute parameter
         self.assertTrue(nwc.get_attr_config(KERNEL).weights_n_bits, 8)
@@ -76,12 +65,10 @@ class TestNodeQuantizationConfigurations(unittest.TestCase):
                          f"Expects set_quant_config_attr to update positional attribute weights_n_bits to 4.")
         self.assertFalse(nwc == og_nwc)
 
-        # Updating an non-existing attribute parameter, no update expected
-        nwc = copy.deepcopy(og_nwc)
-        nwc.set_quant_config_attr("weights_M_bits", 4, attr_name=KERNEL)
-        self.assertTrue(nwc.get_attr_config(KERNEL).weights_n_bits == 8,
-                         f"Expects set_quant_config_attr to not update {KERNEL} attribute weights_n_bits to 4.")
-        self.assertTrue(nwc == og_nwc)
+        with self.assertRaises(AttributeError) as e:
+            nwc.set_quant_config_attr("weights_M_bits", 4, attr_name=KERNEL)
+        self.assertEqual(str(e.exception), f"Parameter weights_M_bits could not be found in the node quantization "
+                                           f"config of weights attribute {KERNEL}.")
 
     def test_get_weights_attr_config(self):
         op_cfg, _, _ = get_op_quantization_configs()

--- a/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
@@ -72,13 +72,8 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
         graph = load_fqc_configuration(graph=graph, fqc=fqc)
 
         for node in graph.nodes:
-            # TODO irena remove set_qc:
-            for c in node.quantization_cfg.candidates_quantization_cfg:
-                c.weights_quantization_cfg.set_qc(core_config.quantization_config)
-
             node.prior_info = keras_impl.get_node_prior_info(node=node,
                                                              graph=graph)
-
         mi = ModelCollector(graph,
                             fw_impl=keras_impl,
                             qc=core_config.quantization_config)

--- a/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
+++ b/tests/keras_tests/non_parallel_tests/test_lp_search_bitwidth.py
@@ -75,8 +75,6 @@ class TestSearchBitwidthConfiguration(unittest.TestCase):
             # TODO irena remove set_qc:
             for c in node.quantization_cfg.candidates_quantization_cfg:
                 c.weights_quantization_cfg.set_qc(core_config.quantization_config)
-                for attr_cfg in c.weights_quantization_cfg.get_all_weight_attrs_configs().values():
-                    attr_cfg.weights_error_method = core_config.quantization_config.weights_error_method
 
             node.prior_info = keras_impl.get_node_prior_info(node=node,
                                                              graph=graph)

--- a/tests/keras_tests/trainable_infrastructure_tests/base_keras_trainable_infra_test.py
+++ b/tests/keras_tests/trainable_infrastructure_tests/base_keras_trainable_infra_test.py
@@ -116,8 +116,7 @@ class BaseKerasTrainableInfrastructureTest:
                                                weights_quantization_params={},
                                                enable_weights_quantization=True,
                                                weights_channels_axis=3,
-                                               weights_per_channel_threshold=True,
-                                               min_threshold=0)
+                                               weights_per_channel_threshold=True)
 
     def get_activation_quantization_config(self):
         return TrainableQuantizerActivationConfig(activation_quantization_method=QuantizationMethod.POWER_OF_TWO,

--- a/tests/keras_tests/trainable_infrastructure_tests/trainable_keras/test_keras_base_quantizer.py
+++ b/tests/keras_tests/trainable_infrastructure_tests/trainable_keras/test_keras_base_quantizer.py
@@ -33,8 +33,7 @@ class TestKerasBaseWeightsQuantizer(BaseKerasTrainableInfrastructureTest):
                                                weights_quantization_params={},
                                                enable_weights_quantization=True,
                                                weights_channels_axis=3,
-                                               weights_per_channel_threshold=True,
-                                               min_threshold=0)
+                                               weights_per_channel_threshold=True)
 
     def run_test(self):
         with self.unit_test.assertRaises(Exception) as e:

--- a/tests/pytorch_tests/function_tests/test_gptq_soft_quantizer.py
+++ b/tests/pytorch_tests/function_tests/test_gptq_soft_quantizer.py
@@ -31,8 +31,7 @@ def wrap_test_model(model, per_channel=False, param_learning=False):
                                            weights_quantization_params={THRESHOLD: 2.0},
                                            enable_weights_quantization=True,
                                            weights_channels_axis=1,
-                                           weights_per_channel_threshold=per_channel,
-                                           min_threshold=MIN_THRESHOLD)
+                                           weights_per_channel_threshold=per_channel)
 
     sq = SymmetricSoftRoundingGPTQ(quantization_config=tqwc,
                                    quantization_parameter_learning=param_learning)

--- a/tests/pytorch_tests/trainable_infrastructure_tests/base_pytorch_trainable_infra_test.py
+++ b/tests/pytorch_tests/trainable_infrastructure_tests/base_pytorch_trainable_infra_test.py
@@ -102,8 +102,7 @@ class BasePytorchInfrastructureTest:
                                                weights_quantization_params={},
                                                enable_weights_quantization=True,
                                                weights_channels_axis=0,
-                                               weights_per_channel_threshold=True,
-                                               min_threshold=0)
+                                               weights_per_channel_threshold=True)
 
     def get_activation_quantization_config(self, quant_method=QuantizationMethod.POWER_OF_TWO,
                                            activation_quant_params=None):

--- a/tests/pytorch_tests/trainable_infrastructure_tests/trainable_pytorch/test_pytorch_base_quantizer.py
+++ b/tests/pytorch_tests/trainable_infrastructure_tests/trainable_pytorch/test_pytorch_base_quantizer.py
@@ -40,8 +40,7 @@ class TestPytorchBaseWeightsQuantizer(BasePytorchInfrastructureTest):
                                                weights_quantization_params={},
                                                enable_weights_quantization=True,
                                                weights_channels_axis=0,
-                                               weights_per_channel_threshold=True,
-                                               min_threshold=0)
+                                               weights_per_channel_threshold=True)
 
     def run_test(self):
 


### PR DESCRIPTION
## Pull Request Description:
*Breaking change:* removed min_threshold from QuantizationConfig.
Remove the temporary patch that injected fields previously read from QuantizationConfig back into NodeWeightsQuantizationConfig and WeightsAttrQuantizationConfig.
Pass QuantizationConfig or its relevant field(s) instead of getting it from the node.
Second moment correction: for now keep weights_second_moment_correction flag in NodeWeightsQuantizationConfig, as it is used to mark the nodes for which to apply the correction and remove the reconstructed BN, but instead of reading from QuantizationConfig, set it in BN reconstruction substitution.
Bias correction:  remove weights_bias_correction flag from NodeWeightsQuantizationConfig. bias_corrected field is still injected into the config, use it instead to determine whether bias correction should be applied. 

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).