### PR TITLE
Refactor fw_info handling in pytest unittests

### DIFF
--- a/tests_pytest/common_tests/unit_tests/core/graph/test_base_node.py
+++ b/tests_pytest/common_tests/unit_tests/core/graph/test_base_node.py
@@ -15,11 +15,9 @@
 import numpy as np
 
 from tests_pytest._test_util.graph_builder_utils import build_node, build_nbits_qc
-from model_compression_toolkit.core.common.framework_info import set_fw_info
 
 
-def test_find_min_max_candidate_index(fw_info_mock):
-    set_fw_info(fw_info_mock)
+def test_find_min_max_candidate_index(patch_fw_info):
     qcs = []
     for ab in [4, 8, 16, 2]:
         for fb in [2, 8, 4]:

--- a/tests_pytest/common_tests/unit_tests/core/graph/test_quantization_preserving_node.py
+++ b/tests_pytest/common_tests/unit_tests/core/graph/test_quantization_preserving_node.py
@@ -16,17 +16,12 @@ import pytest
 
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.core.common.graph.edge import Edge
-from model_compression_toolkit.core.common.framework_info import set_fw_info
 
 from tests_pytest._test_util.graph_builder_utils import build_node, build_nbits_qc
 
 
 class TestQuantizationPreservingNode:
-    @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
-
-    def test_activation_preserving_candidate(self):
+    def test_activation_preserving_candidate(self, patch_fw_info):
         """ Tests that the correct activation quantization candidate is selected. """
         n1 = build_node('qact_node', qcs=[build_nbits_qc()])
         n2 = build_node('qp1a_node', qcs=[build_nbits_qc(a_enable=False, q_preserving=True)])
@@ -42,7 +37,7 @@ class TestQuantizationPreservingNode:
         assert graph.retrieve_preserved_quantization_node(n4) is n4
         assert graph.retrieve_preserved_quantization_node(n5) is n4
 
-    def test_activation_preserving_disable_for_multi_input_node(self):
+    def test_activation_preserving_disable_for_multi_input_node(self, patch_fw_info):
         """ Tests that the retrieve_preserved_quantization_node raises an assertion error if node has more than 1 input. """
         n1 = build_node('qact_node', qcs=[build_nbits_qc()])
         n2 = build_node('qp1a_node', qcs=[build_nbits_qc(a_enable=False, q_preserving=True)])

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_calculator.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_calculator.py
@@ -22,7 +22,6 @@ from model_compression_toolkit.core.common.graph.base_graph import OutTensor
 
 from model_compression_toolkit.constants import FLOAT_BITWIDTH, FUSED_LAYER_PATTERN, FUSED_OP_QUANT_CONFIG
 from model_compression_toolkit.core import ResourceUtilization
-from model_compression_toolkit.core.common.framework_info import set_fw_info
 from model_compression_toolkit.core.common import Graph
 from model_compression_toolkit.core.common.fusion.fusing_info import FusingInfo
 from model_compression_toolkit.core.common.graph.edge import Edge
@@ -69,9 +68,8 @@ class TestComputeResourceUtilization:
         compute_resource_utilization on a virtual graph is tested in TestBOPSAndVirtualGraph
     """
     @pytest.fixture(autouse=True)
-    def setup(self, graph_mock, fw_impl_mock, fw_info_mock):
-        fw_info_mock.get_kernel_op_attribute = Mock(return_value='foo')    # for bops
-        set_fw_info(fw_info_mock)
+    def setup(self, graph_mock, fw_impl_mock, patch_fw_info):
+        patch_fw_info.get_kernel_op_attribute = Mock(return_value='foo')    # for bops
         fw_impl_mock.get_node_mac_operations = lambda n: 42 if n == n2 else 0    # for bops
         n1 = build_node('n1', qcs=[build_qc()], output_shape=(None, 5, 10))
         n2 = build_node('n2', canonical_weights={'foo': np.zeros((3, 14))}, qcs=[build_qc(w_attr={'foo': (4, True)})],
@@ -226,8 +224,8 @@ class TestComputeResourceUtilization:
 
 class TestActivationUtilizationMethods:
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     """ Tests for non-public activation utilization api. """
     def test_get_a_nbits_configurable(self, graph_mock, fw_impl_mock):
@@ -337,8 +335,8 @@ class TestActivationUtilizationMethods:
 
 class TestComputeActivationTensorsUtilization:
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     """ Tests for activation tensors utilization public apis. """
     def test_compute_node_activation_tensor_utilization(self, graph_mock, fw_impl_mock):
@@ -436,8 +434,8 @@ class TestComputeActivationTensorsUtilization:
 
 class TestActivationMaxCutUtilization:
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     """ Tests for activation max cut utilization. """
     def test_compute_cuts_integration(self, graph_mock, fw_impl_mock, mocker):
@@ -737,8 +735,8 @@ class TestActivationMaxCutUtilization:
 class TestWeightUtilizationMethods:
     """ Tests for weights utilization non-public api. """
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     def test_get_w_nbits(self, graph_mock, fw_impl_mock):
         ru_calc = ResourceUtilizationCalculator(graph_mock, fw_impl_mock)
@@ -850,8 +848,8 @@ class TestWeightUtilizationMethods:
 class TestComputeNodeWeightsUtilization:
     """ Tests for compute_node_weight_utilization public method. """
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     @pytest.fixture
     def setup_node_w_test(self, graph_mock, fw_impl_mock):
@@ -940,8 +938,8 @@ class TestComputeNodeWeightsUtilization:
 class TestComputeWeightUtilization:
     """ Tests for compute_weight_utilization public method. """
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     @pytest.fixture
     def prepare_compute_w_util(self, fw_impl_mock):
@@ -1050,8 +1048,8 @@ class TestComputeWeightUtilization:
 class TestCalculatorMisc:
     """ Calculator tests that don't belong to other test classes """
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     def test_calculator_init(self, fw_impl_mock):
         n1 = build_node('n1', qcs=[build_qc(a_enable=False)], output_shape=(None, 5, 10))
@@ -1089,8 +1087,8 @@ class BOPNode:
 
 class TestBOPSAndVirtualGraph:
     @pytest.fixture(autouse=True)
-    def setup(self, fw_info_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, patch_fw_info):
+        pass
 
     def test_compute_regular_node_bops(self, fw_impl_mock, fw_info_mock):
         fw_info_mock.get_kernel_op_attribute = lambda node_type: 'foo' if node_type == BOPNode else None
@@ -1177,7 +1175,7 @@ class TestBOPSAndVirtualGraph:
         with pytest.raises(ValueError, match='BOPS computation is supported only for Any, AnyQuantized and AnyQuantizedNonFused targets.'):
             ru_calc.compute_node_bops(Mock(), target_criterion, BM.Float)
 
-    def test_compute_bops(self, fw_impl_mock, fw_info_mock,):
+    def test_compute_bops(self, fw_impl_mock, fw_info_mock):
         class BOPNode2:
             pass
 

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_data.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/resource_utilization_tools/test_resource_utilization_data.py
@@ -26,7 +26,7 @@ from model_compression_toolkit.core.common.mixed_precision.resource_utilization_
 
 class TestResourceUtilizationData:
     @pytest.mark.parametrize('error_method', [QuantizationErrorMethod.MSE, QuantizationErrorMethod.HMSE])
-    def test_resource_utilization_data(self, fw_info_mock, fw_impl_mock, error_method, mocker):
+    def test_resource_utilization_data(self, fw_impl_mock, error_method, mocker):
         core_cfg = CoreConfig()
         core_cfg.quantization_config.weights_error_method = error_method
         core_cfg.bit_width_config = BitWidthConfig([1, 2])
@@ -42,7 +42,6 @@ class TestResourceUtilizationData:
         prep_runner = mocker.patch('model_compression_toolkit.core.common.mixed_precision.resource_utilization_tools.'
                                    'resource_utilization_data.graph_preparation_runner')
 
-        _current_framework_info = fw_info_mock
         compute_resource_utilization_data(model_mock,
                                           data_gen_mock,
                                           core_cfg,

--- a/tests_pytest/common_tests/unit_tests/core/mixed_precision/sensitivity_eval/test_distance_calculator.py
+++ b/tests_pytest/common_tests/unit_tests/core/mixed_precision/sensitivity_eval/test_distance_calculator.py
@@ -17,7 +17,6 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from model_compression_toolkit.core.common.framework_info import set_fw_info
 from model_compression_toolkit.core import MixedPrecisionQuantizationConfig, MpDistanceWeighting
 from model_compression_toolkit.core.common.hessian import HessianInfoService
 from model_compression_toolkit.core.common.mixed_precision.sensitivity_eval.metric_calculators import \
@@ -34,8 +33,7 @@ class TestDistanceWeighting:
     out_pts = np.array([[1, 2], [3, 4], [5, 6]])
 
     @pytest.fixture
-    def setup(self, mocker, graph_mock, fw_info_mock, fw_impl_mock):
-        set_fw_info(fw_info_mock)
+    def setup(self, mocker, graph_mock, patch_fw_info, fw_impl_mock):
         mocker.patch.object(DistanceMetricCalculator, 'get_mp_interest_points', return_value=[None, None])
         mocker.patch.object(DistanceMetricCalculator, 'get_output_nodes_for_metric', return_value=[None])
         mocker.patch.object(DistanceMetricCalculator, '_init_metric_points_lists', return_value=(None, None))

--- a/tests_pytest/common_tests/unit_tests/core/test_fusion_info.py
+++ b/tests_pytest/common_tests/unit_tests/core/test_fusion_info.py
@@ -262,7 +262,7 @@ def fusing_info_generator_with_qconfig(fusing_patterns_with_qconfig):
     return FusingInfoGenerator(fusing_patterns_with_qconfig)
 
 @pytest.fixture
-def mock_qconfig_set_nodes():
+def mock_qconfig_set_nodes(patch_fw_info):
     """
     Creates mock nodes representing a simple neural network structure.
     - Nodes: Conv2D, ReLU, Conv2D, Tanh, Linear, Softmax.

--- a/tests_pytest/conftest.py
+++ b/tests_pytest/conftest.py
@@ -23,7 +23,6 @@ from tests_pytest._test_util import tpc_util
 
 
 class DummyFrameworkInfo(FrameworkInfo):
-    activation_quantizer_mapping = {}
     kernel_channels_mapping = {}
     _layer_min_max_mapping = {}
     kernel_ops_attribute_mapping = {}


### PR DESCRIPTION
## Pull Request Description:
Switch pytest unittests to fw_info patch instead of changing the global _current_framework_info state.
Remove activation_quantizer_mapping from DummyFrameworkInfo in tests.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).