### PR TITLE
[SSS Review]limit pydantic version(<2.12.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ matplotlib<3.10.0
 scipy
 protobuf
 mct-quantizers==1.6.0
-pydantic>=2.0
+pydantic>=2.0,<2.12.0
 edge-mdt-cl-dev


### PR DESCRIPTION
## Pull Request Description:
* limit pydantic version(<2.12.0)
    * Added restrictions to MCT requirements due to usage of functions not supported in pydantic 2.12.0(2025/10/08 Release).

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).